### PR TITLE
chore: fixvault

### DIFF
--- a/helm/webapp/templates/deployment.yaml
+++ b/helm/webapp/templates/deployment.yaml
@@ -21,6 +21,8 @@ spec:
       annotations:
         vault.hashicorp.com/agent-inject: 'true'
         vault.hashicorp.com/agent-inject-token: 'true'
+        vault.hashicorp.com/agent-init-first: 'true'
+        vault.hashicorp.com/agent-pre-populate: 'true'
         vault.hashicorp.com/auth-path: auth/k8s-silver
         vault.hashicorp.com/namespace: platform-services
         vault.hashicorp.com/role: {{ .Values.vault.vaultSecretEngine }}
@@ -55,6 +57,8 @@ spec:
           command: ["bash", "-c"]
           args:
             - |
+              echo set vault environment variables
+              source /vault/secrets/postgres;
               echo starting;
               set -euo pipefail;
               psql -d $PGDATABASE_NAME -qtA --set ON_ERROR_STOP=1 << 'EOF'
@@ -68,16 +72,6 @@ spec:
               value: {{ .Values.postgres.host }}
             - name: PGPORT
               value: {{ .Values.postgres.port | quote }}
-            - name: PGUSER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.postgres.username.secret }}
-                  key: {{ .Values.postgres.username.key }}
-            - name: PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.postgres.password.secret }}
-                  key: {{ .Values.postgres.password.key }}
             - name: PGDATABASE_NAME
               value: {{ .Values.postgres.database }}
       serviceAccountName:  {{ .Values.vault.serviceAccountName }}

--- a/helm/webapp/templates/deployment.yaml
+++ b/helm/webapp/templates/deployment.yaml
@@ -57,9 +57,7 @@ spec:
           command: ["bash", "-c"]
           args:
             - |
-              echo set vault environment variables
               source /vault/secrets/postgres;
-              echo starting;
               set -euo pipefail;
               psql -d $PGDATABASE_NAME -qtA --set ON_ERROR_STOP=1 << 'EOF'
               {{ .Files.Get "migration.sql" | nindent 20 -}}


### PR DESCRIPTION
This allows the postgres credentials to be properly loaded into the initContainer.  Opening up the path for integrating vault with the patroni helm chart.