### PR TITLE
Realm registry updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ yarn-error.log*
 *.key
 *.cert
 get-pip.py
+venv

--- a/app/layout/Layout.tsx
+++ b/app/layout/Layout.tsx
@@ -149,7 +149,7 @@ const RightMenuItems = () => (
       </a>
     </HoverItem>
     <HoverItem>
-      <a href="https://github.com/bcgov/ocp-sso/wiki" target="_blank" title="Documentation" rel="noreferrer">
+      <a href="https://github.com/bcgov/sso-keycloak/wiki" target="_blank" title="Documentation" rel="noreferrer">
         <FontAwesomeIcon size="2x" icon={faFileAlt} />
       </a>
     </HoverItem>
@@ -190,7 +190,7 @@ function Layout({ children, onLoginClick, onLogoutClick }: any) {
           <FontAwesomeIcon size="2x" icon={faEnvelope} />
         </a>
         &nbsp;&nbsp;
-        <a href="https://github.com/bcgov/ocp-sso/wiki" target="_blank" title="Wiki" rel="noreferrer">
+        <a href="https://github.com/bcgov/sso-keycloak/wiki" target="_blank" title="Wiki" rel="noreferrer">
           <FontAwesomeIcon size="2x" icon={faFileAlt} />
         </a>
       </li>

--- a/app/page-partials/my-dashboard/RealmTable.tsx
+++ b/app/page-partials/my-dashboard/RealmTable.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Button from '@button-inc/bcgov-theme/Button';
 import { RealmProfile } from 'types/realm-profile';
 import Table from 'components/Table';
+import Link from '@button-inc/bcgov-theme/Link';
 
 interface Props {
   realms: RealmProfile[];
@@ -91,7 +92,7 @@ function RealmTable({ realms, onEditClick }: Props) {
           },
           {
             header: 'Rocket Chat Channel',
-            cell: (row) => row.renderValue(),
+            cell: (row) =>  <Link href={row.renderValue() as string} external>Rocketchat</Link>,            
             accessorKey: 'rcChannel',
           },
           {

--- a/app/page-partials/my-dashboard/RealmTable.tsx
+++ b/app/page-partials/my-dashboard/RealmTable.tsx
@@ -92,7 +92,11 @@ function RealmTable({ realms, onEditClick }: Props) {
           },
           {
             header: 'Rocket Chat Channel',
-            cell: (row) =>  <Link href={row.renderValue() as string} external>Rocketchat</Link>,            
+            cell: (row) => (
+              <Link href={row.renderValue() as string} external>
+                Rocketchat
+              </Link>
+            ),
             accessorKey: 'rcChannel',
           },
           {

--- a/app/pages/api/realms/all.ts
+++ b/app/pages/api/realms/all.ts
@@ -21,6 +21,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     return res.send(realms);
   } catch (err: any) {
     console.error(err);
-    res.status(200).json({ success: false, error: err.message || err });
+    res.status(500).json({ success: false, error: err.message || err });
   }
 }

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -46,7 +46,11 @@ const Home = () => {
   };
 
   const handleDashboard = async () => {
-    router.push(`/my-dashboard`);
+    if (session?.status === 'authenticated') {
+      router.push(`/my-dashboard`);
+    } else {
+      handleLogin();
+    }
   };
 
   return (

--- a/app/pages/my-dashboard.tsx
+++ b/app/pages/my-dashboard.tsx
@@ -97,13 +97,14 @@ function MyDashboard() {
     setSelectedId(null);
   };
 
-  if (hasError) return (
-    <TopAlertWrapper>
-    <Alert variant="warning" closable={true}>
-      There was en error while loading your realm information. Please try refreshing the page.
-    </Alert>
-  </TopAlertWrapper>
-  );
+  if (hasError)
+    return (
+      <TopAlertWrapper>
+        <Alert variant="warning" closable={true}>
+          There was en error while loading your realm information. Please try refreshing the page.
+        </Alert>
+      </TopAlertWrapper>
+    );
 
   return (
     <>

--- a/app/pages/my-dashboard.tsx
+++ b/app/pages/my-dashboard.tsx
@@ -97,7 +97,13 @@ function MyDashboard() {
     setSelectedId(null);
   };
 
-  if (hasError) return null;
+  if (hasError) return (
+    <TopAlertWrapper>
+    <Alert variant="warning" closable={true}>
+      There was en error while loading your realm information. Please try refreshing the page.
+    </Alert>
+  </TopAlertWrapper>
+  );
 
   return (
     <>


### PR DESCRIPTION
- Update wiki links
- make the rocketchat url in the table a link
- Prompt users to login if they click "My Dashboard" while unauthenticated

I updated an API route to return 500 on error, it was giving a 200 even if failing which caused some strange behaviour on the frontend for me. Put in a small alert banner so users can see if the realms didnt load properly.