### PR TITLE
fix: timer reset

### DIFF
--- a/app/layout/Layout.tsx
+++ b/app/layout/Layout.tsx
@@ -209,8 +209,8 @@ function Layout({ children, onLoginClick, onLogoutClick }: any) {
       onLogoutClick();
     },
     timeout: 30 * 60 * 1000,
-    promptBeforeIdle: 25 * 60 * 1000,
-    disabled: session?.status !== 'authenticated',
+    promptBeforeIdle: 5 * 60 * 1000,
+    disabled: !['authenticated', 'loading'].includes(session?.status),
   });
 
   const rightSide = currentUser ? (


### PR DESCRIPTION
- stop idle timer resetting on session refresh (status briefly flips to loading)
- Prompt 5 minutes before idle instead of 25