### PR TITLE
chore: update email list

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 nodejs 20.17.0
 yarn 1.22.22
 python 3.11.0
-postgres 11.4
+postgres 14.1
 helm 3.10.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 nodejs 20.17.0
 yarn 1.22.22
 python 3.11.0
-postgres 14.1
+postgres 11.4
 helm 3.10.2

--- a/app/utils/mailer.ts
+++ b/app/utils/mailer.ts
@@ -247,9 +247,7 @@ export const sendReadyToUseEmail = async (realm: Roster) => {
   const realmName = realm.realm!;
   return await sendEmail({
     cc: [ssoTeamEmail],
-    to: [realm.technicalContactEmail!, realm.productOwnerEmail!, realm.secondTechnicalContactEmail!].filter(
-      (email) => email,
-    ),
+    to: [realm.technicalContactEmail!, realm.productOwnerEmail!].filter((email) => email),
     body: `
           ${emailHeader}
             <main>


### PR DESCRIPTION
Taking the secondary tech contact off the "ready to use" email list. This email has instructions for updating roles that the secondary cannot do, as they don't get master realm login access.